### PR TITLE
FPS #18: プレイヤー移動（WASD・ジャンプ・重力・照準）+ termray render パイプ統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to friendly-filer are documented in this file. The format is
 ## [Unreleased]
 
 ### Added
+- Playable first-person walk-around ([#18](https://github.com/kako-jun/friendly-filer/issues/18)).
+  New `input.rs` (crossterm → `FrameInput`), `physics.rs` (WASD / Shift / Space / arrow
+  motion with axis-aligned Doom-style wall slide, gravity, jump, yaw wrap, pitch clamp),
+  and `render.rs` (half-block `present`, `WallTextureFlat`, `FloorTextureGrid` TRON
+  adapters). `DirScene::placeholder` now ships an 8×8 `GridMap` + `FlatHeightMap` +
+  `spawn_yaw` with `map()` / `heights()` / `camera()` accessors. `main.rs` becomes a
+  60 FPS loop driving termray's real `cast_all_rays` → `render_floor_ceiling` →
+  `render_walls` pipeline. F1 toggles an FPS-OFF mode (HUD label only until #16). Esc /
+  q quit cleanly. 24 unit tests green (8 physics + 4 render + 3 scene + previously-green
+  skeleton tests).
 - FPS layer skeleton ([#8](https://github.com/kako-jun/friendly-filer/issues/8)).
   New simulation-layer modules land in `src/`: `palette` (TRON 3-color constants),
   `player`, `enemy` (with extension-based classification + `log(size)` HP + `Swarm`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,18 @@ simulation layer is pure Rust; rendering is outsourced to termray.
 
 ### Module map (`src/`)
 
-- `main.rs` — entry point, terminal guard, current demo frame
+- `main.rs` — entry point, terminal guard, 60 FPS frame loop
 - `lib.rs` — public re-exports of the modules below
 - `palette.rs` — TRON 3-color constants (`BG_BLACK`, `GRID_BLUE`,
   `ENEMY_RED`, `GEOMETRY_GRAY`, `UI_BLUE`, `WARN_RED`)
-- `player.rs` — `Player`, `new`, `is_crashed` (movement & jump in #18)
+- `player.rs` — `Player`, `new`, `is_crashed` (data only; motion lives
+  in `physics.rs`)
+- `input.rs` — `FrameInput`, `poll_frame_input` (crossterm → frame
+  intents; WASD / Space / arrows / Shift / F1 / Esc)
+- `physics.rs` — `step_movement`, `step_gravity`, `try_jump`,
+  `add_yaw`, `add_pitch`, tunable `pub const`s (config override in #17)
+- `render.rs` — `present`, `WallTextureFlat`, `FloorTextureGrid`
+  (TRON-coloured termray adapters + half-block stdout flush)
 - `enemy.rs` — `EnemyKind`, `Enemy`, `Enemy::from_metadata`, `Swarm`
   (AI in #9)
 - `disc.rs` — `DiscState`, `Disc`, `is_ready` (physics in #10)
@@ -38,8 +45,9 @@ simulation layer is pure Rust; rendering is outsourced to termray.
 - `menu.rs` — `Operation`, `MenuContext` (effects & undo in #12)
 - `hud.rs` — `Hud`, `Mode` (full HUD in #13)
 - `config.rs` — `Config` + `Default`, `AimStyle` (TOML in #17)
-- `scene.rs` — `DirScene` placeholder (real directory → scene in the
-  absorbed #3 scope)
+- `scene.rs` — `DirScene` with placeholder `GridMap` + `FlatHeightMap`
+  + `spawn_yaw`; `map()` / `heights()` / `camera()` accessors drive the
+  termray pipeline. Real `read_dir` → scene in the absorbed #3 scope.
 
 All modules ship with unit tests at the skeleton stage (10 tests green).
 
@@ -82,15 +90,20 @@ cargo fmt --all
 cargo test
 ```
 
-`cargo run` currently paints one TRON frame (black + blue grid + red
-enemy box + blue banner) for ~0.8 s and exits cleanly.
+`cargo run` now drops into a playable first-person walk-around: an
+8×8 TRON arena rendered by the real termray raycaster, with WASD
+movement, Shift to sprint, Space to jump (single, gravity), arrow keys
+for yaw / pitch aim, F1 toggling FPS-OFF, and Esc / q quitting. A
+minimal debug HUD prints position, yaw, pitch, vz and HP at the bottom
+of the screen.
 
 ## Current stage
 
-Skeleton of the FPS layer (#8). Module shapes, palette, one demo frame,
-`docs/fps-spec.md`. Movement, enemies, disc, portals, menus, HUD,
-search, input mode, FPS-OFF, config and real filesystem reads all land
-in #9 – #18.
+FPS layer skeleton (#8) + playable walk-around (#18). Module shapes,
+palette, scene-backed termray pipeline, input / physics / render
+modules. Enemies, disc, portals, menus, full HUD, search, input mode,
+FPS-OFF content, config and real filesystem reads all land in #9 –
+#17.
 
 ## Roadmap
 
@@ -106,7 +119,7 @@ in #9 – #18.
 | #15 | Input mode (rename, new file, new folder) |
 | #16 | FPS OFF, preview, shell integration (`--cd-on-exit`) |
 | #17 | Config (palette, keys, LOD thresholds) |
-| #18 | Player movement (WASD / hjkl, jump, gravity, aim) |
+| #18 | Player movement (WASD, jump, gravity, aim) — **done** |
 
 The earlier Phase 1–4 issues (#3 – #6) remain open for reference but
 are superseded by #9 – #18.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,30 +63,59 @@ feeding it the scene data produced by `DirScene`.
 | `menu.rs` | skeleton (#8) | `Operation { Open, Rename, Move, Copy, Delete, Info, Cancel }` and `MenuContext { File, Swarm, Folder, Monolith }`. Real menu + effects land in #12. |
 | `hud.rs` | skeleton (#8) | `Hud { hp, score, .. }`, `Mode { Fps, FpsOff, Frozen, Crashed }`. Full HUD lands in #13. |
 | `config.rs` | skeleton (#8) | `Config` with `Default`, `AimStyle { Keyboard, Mouse }`. Real TOML loader lands in #17. |
-| `scene.rs` | skeleton (#8) | `DirScene` placeholder returning a single dummy enemy. Real directory → scene conversion lands in #3 (absorbed into the FPS layer). |
-| `main.rs` | demo (#8) | Renders one TRON-palette frame (black bg, blue grid, red enemy placeholder, blue banner) for ~0.8 s and exits. |
+| `scene.rs` | extended (#18) | `DirScene` now owns an 8×8 `GridMap` + `FlatHeightMap` + `spawn_yaw`, with `map()` / `heights()` / `camera()` accessors that feed termray's raycaster. Real `read_dir` → scene work still lands in #3. |
+| `input.rs` | done (#18) | Crossterm `event::poll` → `FrameInput { forward, strafe, run, jump, yaw_delta, pitch_delta, toggle_fps_off, quit }`. Press / Repeat are both treated as one frame of input; Release is ignored. Mouse aim is deferred to #16. |
+| `physics.rs` | done (#18) | Pure functions on `Player`: `step_movement` (axis-aligned Doom slide), `step_gravity`, `try_jump`, `add_yaw`, `add_pitch`. Tunables live as module `pub const`s; TOML config lands in #17. |
+| `render.rs` | done (#18) | Framebuffer → stdout `present()` (half-block), plus `WallTextureFlat` and `FloorTextureGrid` TRON adapters for termray's `WallTexturer` / `FloorTexturer` traits. |
+| `main.rs` | FPS loop (#18) | 60 FPS frame loop: input → physics → camera sync → `cast_all_rays` → `render_floor_ceiling` + `render_walls` → debug HUD → `present`. Esc / q quit; F1 toggles FPS-OFF mode. The #8 static demo frame has been removed. |
 
-## Current state (#8 skeleton)
+## Current state (#18 playable walk-around)
 
 What `cargo run` does today:
 
-1. Reads terminal size via `crossterm::terminal::size`.
-2. Allocates a `termray::Framebuffer` sized to the terminal (half-block
-   vertical doubling applied).
-3. Paints a single TRON-palette frame:
-   - black background,
-   - converging blue floor grid with a blue horizon line,
-   - a gray-filled, red-outlined rectangle in the middle as an enemy
-     placeholder,
-   - a blue `Font8x8` banner near the bottom.
-4. Enters the alternate screen, hides the cursor, enables raw mode via
-   a RAII `TerminalGuard`.
-5. Sleeps 800 ms so the frame is visible.
-6. Drops the guard, restoring the terminal, and exits cleanly.
+1. Reads terminal size via `crossterm::terminal::size` and allocates a
+   half-block-doubled `termray::Framebuffer`.
+2. Builds an 8×8 `DirScene::placeholder()` — solid outer ring, 6×6
+   walkable interior, one demo enemy, one central monolith.
+3. Enters the alternate screen + raw mode via `TerminalGuard`.
+4. Runs a 60 FPS frame loop driving the **real** termray raycaster:
+   - `input::poll_frame_input` drains crossterm events into a
+     `FrameInput`;
+   - `physics::step_movement` / `try_jump` / `step_gravity` /
+     `add_yaw` / `add_pitch` update the `Player`;
+   - `Camera::set_pose` / `set_z` / `set_pitch` sync the camera;
+   - `render_floor_ceiling` + `render_walls` rasterize the frame into
+     the framebuffer using `FloorTextureGrid` + `WallTextureFlat`;
+   - a single `Font8x8` debug line prints pos / yaw / pitch / vz /
+     HP / MODE at the bottom of the screen;
+   - `render::present` flushes the framebuffer with half-block
+     characters, then the loop sleeps to hit the 16 ms frame budget.
+5. Esc or `q` terminates; `TerminalGuard::drop` restores the terminal.
 
-No input loop, no filesystem reads, no real enemies, no disc, no menu —
-those arrive with issues #9–#18. All 10 simulation-layer unit tests are
-green.
+The #8 static demo frame (hand-drawn floor fan, red enemy rectangle,
+bottom-centre banner) has been removed. The draw_floor_grid /
+draw_enemy_placeholder / draw_banner helpers are gone, replaced by the
+termray pipeline above.
+
+### Physics tunables (`src/physics.rs`)
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MOVE_SPEED` | `3.0` | World units / second, walking. |
+| `RUN_MULTIPLIER` | `1.8` | Held-Shift sprint multiplier. |
+| `JUMP_INITIAL_VZ` | `4.5` | Upward velocity on jump. |
+| `GRAVITY` | `12.0` | Downward acceleration. |
+| `GROUND_Z` | `0.5` | Eye height on the floor (matches termray default). |
+| `AIM_YAW_RATE` | `2.0` | rad / s for arrow-key yaw. |
+| `AIM_PITCH_RATE` | `1.5` | rad / s for arrow-key pitch. |
+| `PITCH_MAX` | `π/2 − 0.05` | Pitch clamp (avoids tan() singularity). |
+| `PLAYER_RADIUS` | `0.25` | Collision circle radius. |
+
+All of these become TOML-overridable in #17.
+
+Enemy AI, disc physics and sealed-portal geometry still arrive with
+issues #9 – #17. The simulation-layer unit tests plus the new physics
+and render tests total 24 green.
 
 ## Sub-issue graph (FPS layer)
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,44 +1,62 @@
 //! Input loop: crossterm key events → high-level frame intents.
 //!
-//! crossterm's raw-mode `KeyEvent` stream only delivers `Press` and `Repeat`
-//! kinds on most terminals (there is no `KeyUp`), so continuous-motion
-//! controls are implemented by treating every observed event as
-//! "apply one frame's worth of motion". Holding W produces repeat events
-//! at the terminal's key-repeat rate and the player glides forward; releasing
-//! simply stops the events. This matches how vintage roguelikes handle
-//! hold-to-move and keeps us away from platform-specific raw keyboard APIs.
+//! The input layer keeps a small [`InputState`] that remembers **when each
+//! motion key was last seen** (pressed or auto-repeated). A key is treated
+//! as "held" if its last-seen timestamp is within [`KEY_HOLD_TIMEOUT`] of
+//! the current frame. This gives us OS-key-repeat-rate-independent motion
+//! (W held for 1 s advances exactly `MOVE_SPEED × 1 s` regardless of
+//! whether the terminal fires 20 or 120 repeat events per second) and also
+//! lets us correctly handle kitty / win32 `Release` events when they are
+//! delivered — a release instantly drops the key from the tracker.
+//!
+//! One-shot actions (F1 toggle, Esc / q quit, space jump) are handled on
+//! the `Press` event itself and do not go through the held-key table.
 //!
 //! Mouse aim is deliberately deferred to #16; arrow keys are the canonical
 //! #18 aim binding.
 
-use std::time::Duration;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+/// How long a key is considered "still held" after the most recent
+/// `Press` / `Repeat` event. Must be longer than a typical terminal's
+/// key-repeat interval (usually 30–50 ms) but short enough that releasing
+/// the key stops motion before the player drifts visibly. 120 ms is a
+/// comfortable middle ground and matches the "feel" of the pre-refactor
+/// event-count model at default repeat rates.
+pub const KEY_HOLD_TIMEOUT: Duration = Duration::from_millis(120);
+
+/// Hard cap on the number of crossterm events drained in a single
+/// [`poll_frame_input`] call. Without this, a user hammering keys (or a
+/// terminal flooding us with bracketed-paste input) could monopolise the
+/// frame. 128 is well above any realistic held-key burst at 60 FPS and
+/// still prevents pathological stalls.
+pub const MAX_EVENTS_PER_FRAME: usize = 128;
 
 /// The collected set of actions triggered in one frame poll.
 ///
-/// All fields are zero / `false` in the "nothing happened" baseline;
-/// the frame loop adds them into the player's state via
-/// [`crate::physics`]. `forward` / `strafe` are *event counts*: each
-/// `Press` or `Repeat` of the key bumps them by 1, and the caller
-/// multiplies by [`crate::physics::MOVE_SPEED`] × frame_dt so the motion
-/// per second ends up proportional to the terminal's key-repeat rate
-/// (which the user can tune in their OS settings if they want snappier
-/// controls).
+/// Fields are populated from [`InputState`] on each
+/// [`poll_frame_input`] call. `forward` / `strafe` / `yaw_delta` /
+/// `pitch_delta` are always in `[-1.0, 1.0]` (clamped before return) and
+/// are continuous while the relevant key is held — OS key-repeat rate no
+/// longer factors in.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FrameInput {
-    /// Net forward intent. W adds +1, S subtracts 1.
+    /// Net forward intent. W held = +1, S held = −1, both / neither = 0.
     pub forward: f64,
-    /// Net strafe intent. D adds +1, A subtracts 1.
+    /// Net strafe intent. D held = +1, A held = −1.
     pub strafe: f64,
-    /// Shift held while moving — apply [`crate::physics::RUN_MULTIPLIER`].
+    /// Shift held while any motion key is held — apply
+    /// [`crate::physics::RUN_MULTIPLIER`].
     pub run: bool,
-    /// A jump was requested this frame.
+    /// A jump was requested this frame (Space pressed).
     pub jump: bool,
-    /// Net yaw delta in "event units" (Left = -1, Right = +1). The caller
-    /// scales by [`crate::physics::AIM_YAW_RATE`] × dt.
+    /// Net yaw delta. Right held = +1, Left held = −1. Caller scales by
+    /// [`crate::physics::AIM_YAW_RATE`] × dt.
     pub yaw_delta: f64,
-    /// Net pitch delta. Up = +1 (look up), Down = -1.
+    /// Net pitch delta. Up held = +1, Down held = −1.
     pub pitch_delta: f64,
     /// F1 was pressed — toggle FPS OFF (handled by the caller).
     pub toggle_fps_off: bool,
@@ -46,20 +64,144 @@ pub struct FrameInput {
     pub quit: bool,
 }
 
-/// Drain all currently-pending crossterm events and fold them into a single
-/// [`FrameInput`]. Returns `Ok(FrameInput::default())` if nothing was
-/// pending after `poll_timeout`.
-///
-/// `poll_timeout` is forwarded to [`event::poll`]; pass `Duration::ZERO`
-/// for a non-blocking read (the common case inside a 60 FPS frame loop).
-pub fn poll_frame_input(poll_timeout: Duration) -> anyhow::Result<FrameInput> {
-    let mut fi = FrameInput::default();
+/// Persistent input state carried across frames. Remembers the last time
+/// each motion key was pressed / auto-repeated, plus the running
+/// mode-toggle / quit flags.
+#[derive(Debug, Default)]
+pub struct InputState {
+    /// Last-seen-pressed timestamp for every motion key currently
+    /// considered "live". Pruned on `Release` events and by time-based
+    /// held-check during [`poll_frame_input`].
+    key_last_seen: HashMap<KeyCode, Instant>,
+    /// Whether the most recent press involved the Shift modifier. Used to
+    /// derive [`FrameInput::run`] as long as any motion key is held.
+    shift_held: bool,
+}
 
-    // First poll with the caller's timeout; subsequent polls must be
-    // non-blocking so we don't wait out the full timeout for each event
-    // in a burst (e.g. a held key).
+impl InputState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Is `code` currently considered held at time `now`?
+    fn is_held(&self, code: KeyCode, now: Instant) -> bool {
+        match self.key_last_seen.get(&code) {
+            Some(&t) => now.duration_since(t) <= KEY_HOLD_TIMEOUT,
+            None => false,
+        }
+    }
+
+    /// Held check as a signed contribution to an axis (returns 1.0 / 0.0).
+    fn axis(&self, code: KeyCode, now: Instant) -> f64 {
+        if self.is_held(code, now) { 1.0 } else { 0.0 }
+    }
+}
+
+/// One-shot action produced by [`apply_key`] — press events that do not
+/// map onto the held-key table. Continuous motion events return `None`
+/// because they are handled via `key_last_seen` updates as a side-effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputAction {
+    /// Space was pressed this frame.
+    Jump,
+    /// F1 was pressed this frame.
+    ToggleFpsOff,
+    /// Esc or q was pressed this frame.
+    Quit,
+}
+
+/// Fold a single crossterm [`KeyEvent`] into the persistent input state,
+/// returning any one-shot action triggered by it. Motion keys update the
+/// `key_last_seen` table as a side-effect and return `None`.
+///
+/// Release events prune the released key from `key_last_seen` immediately
+/// (for terminals that deliver releases, e.g. kitty with the keyboard
+/// enhancement flags enabled).
+pub(crate) fn apply_key(state: &mut InputState, ev: KeyEvent, now: Instant) -> Option<InputAction> {
+    // Normalise letter keys to their lowercase form so we don't track
+    // `'W'` and `'w'` as two separate held keys when Shift is held.
+    let code = normalise(ev.code);
+
+    if matches!(ev.kind, KeyEventKind::Release) {
+        state.key_last_seen.remove(&code);
+        if matches!(
+            code,
+            KeyCode::Char('w') | KeyCode::Char('a') | KeyCode::Char('s') | KeyCode::Char('d')
+        ) && !state.key_last_seen.keys().any(|k| {
+            matches!(
+                k,
+                KeyCode::Char('w') | KeyCode::Char('a') | KeyCode::Char('s') | KeyCode::Char('d')
+            )
+        }) {
+            state.shift_held = false;
+        }
+        return None;
+    }
+
+    // Press or Repeat.
+    match code {
+        // Motion keys → refresh held timestamp.
+        KeyCode::Char('w')
+        | KeyCode::Char('a')
+        | KeyCode::Char('s')
+        | KeyCode::Char('d')
+        | KeyCode::Up
+        | KeyCode::Down
+        | KeyCode::Left
+        | KeyCode::Right => {
+            state.key_last_seen.insert(code, now);
+            // Shift is sampled from the most recent motion press. The
+            // uppercase-letter path (some terminals deliver `'W'` without
+            // a SHIFT modifier bit) also counts as a run signal.
+            let shift_bit = ev.modifiers.contains(KeyModifiers::SHIFT);
+            let uppercase = matches!(
+                ev.code,
+                KeyCode::Char('W') | KeyCode::Char('A') | KeyCode::Char('S') | KeyCode::Char('D')
+            );
+            if matches!(
+                code,
+                KeyCode::Char('w') | KeyCode::Char('a') | KeyCode::Char('s') | KeyCode::Char('d')
+            ) {
+                state.shift_held = shift_bit || uppercase;
+            }
+            None
+        }
+
+        // One-shot actions.
+        KeyCode::Char(' ') => Some(InputAction::Jump),
+        KeyCode::F(1) => Some(InputAction::ToggleFpsOff),
+        KeyCode::Esc => Some(InputAction::Quit),
+        KeyCode::Char('q') => Some(InputAction::Quit),
+
+        _ => None,
+    }
+}
+
+/// Collapse letter casing so `'W'` and `'w'` are treated as the same
+/// tracked key. All other codes pass through unchanged.
+fn normalise(code: KeyCode) -> KeyCode {
+    match code {
+        KeyCode::Char(c) if c.is_ascii_uppercase() => KeyCode::Char(c.to_ascii_lowercase()),
+        other => other,
+    }
+}
+
+/// Drain pending crossterm events into `state`, then snapshot the current
+/// held-key set into a [`FrameInput`].
+///
+/// `poll_timeout` is forwarded to the first [`event::poll`]; subsequent
+/// polls are non-blocking. At most [`MAX_EVENTS_PER_FRAME`] events are
+/// drained per call to bound the worst-case frame time.
+pub fn poll_frame_input(
+    state: &mut InputState,
+    poll_timeout: Duration,
+) -> anyhow::Result<FrameInput> {
+    let mut jump = false;
+    let mut toggle_fps_off = false;
+    let mut quit = false;
+
     let mut first = true;
-    loop {
+    for _ in 0..MAX_EVENTS_PER_FRAME {
         let wait = if first { poll_timeout } else { Duration::ZERO };
         first = false;
         if !event::poll(wait)? {
@@ -67,62 +209,167 @@ pub fn poll_frame_input(poll_timeout: Duration) -> anyhow::Result<FrameInput> {
         }
         match event::read()? {
             Event::Key(k) => {
-                // Ignore Release events; we only care about Press / Repeat.
-                // (crossterm raw mode emits Press on most terminals and
-                // Press+Repeat on kitty / win32; Release is rare but we're
-                // future-proof against it.)
-                if matches!(k.kind, KeyEventKind::Release) {
-                    continue;
+                if let Some(action) = apply_key(state, k, Instant::now()) {
+                    match action {
+                        InputAction::Jump => jump = true,
+                        InputAction::ToggleFpsOff => toggle_fps_off = true,
+                        InputAction::Quit => quit = true,
+                    }
                 }
-                apply_key(&mut fi, k.code, k.modifiers);
             }
             // Non-key events are ignored in #18; mouse aim lands in #16.
             _ => continue,
         }
     }
 
-    Ok(fi)
+    let now = Instant::now();
+
+    // Prune stale entries so the table doesn't grow unbounded on
+    // terminals that never emit releases and the user walks through a
+    // great many keys over a long session.
+    state
+        .key_last_seen
+        .retain(|_, t| now.duration_since(*t) <= KEY_HOLD_TIMEOUT);
+
+    let any_wasd = [
+        KeyCode::Char('w'),
+        KeyCode::Char('a'),
+        KeyCode::Char('s'),
+        KeyCode::Char('d'),
+    ]
+    .iter()
+    .any(|k| state.is_held(*k, now));
+    if !any_wasd {
+        state.shift_held = false;
+    }
+
+    let forward = state.axis(KeyCode::Char('w'), now) - state.axis(KeyCode::Char('s'), now);
+    let strafe = state.axis(KeyCode::Char('d'), now) - state.axis(KeyCode::Char('a'), now);
+    // Right = yaw +, Left = yaw − (matches the pre-refactor convention
+    // so existing physics tests continue to assert the same direction).
+    let yaw_delta = state.axis(KeyCode::Right, now) - state.axis(KeyCode::Left, now);
+    let pitch_delta = state.axis(KeyCode::Up, now) - state.axis(KeyCode::Down, now);
+
+    Ok(FrameInput {
+        forward: forward.clamp(-1.0, 1.0),
+        strafe: strafe.clamp(-1.0, 1.0),
+        run: state.shift_held && any_wasd,
+        jump,
+        yaw_delta: yaw_delta.clamp(-1.0, 1.0),
+        pitch_delta: pitch_delta.clamp(-1.0, 1.0),
+        toggle_fps_off,
+        quit,
+    })
 }
 
-fn apply_key(fi: &mut FrameInput, code: KeyCode, mods: KeyModifiers) {
-    // Track Shift as the "run" modifier any time a motion key fires.
-    let shift = mods.contains(KeyModifiers::SHIFT);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
-    match code {
-        // --- Movement ---
-        KeyCode::Char('w') | KeyCode::Char('W') => {
-            fi.forward += 1.0;
-            fi.run |= shift;
+    fn press(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: mods,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::empty(),
         }
-        KeyCode::Char('s') | KeyCode::Char('S') => {
-            fi.forward -= 1.0;
-            fi.run |= shift;
+    }
+
+    fn release(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::empty(),
+            kind: KeyEventKind::Release,
+            state: KeyEventState::empty(),
         }
-        KeyCode::Char('a') | KeyCode::Char('A') => {
-            fi.strafe -= 1.0;
-            fi.run |= shift;
-        }
-        KeyCode::Char('d') | KeyCode::Char('D') => {
-            fi.strafe += 1.0;
-            fi.run |= shift;
-        }
+    }
 
-        // --- Jump ---
-        KeyCode::Char(' ') => fi.jump = true,
+    #[test]
+    fn apply_key_w_marks_forward_held() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::Char('w'), KeyModifiers::NONE), t0);
+        assert!(action.is_none());
+        assert!(st.is_held(KeyCode::Char('w'), t0));
+        assert!(!st.shift_held);
+    }
 
-        // --- Aim (arrow keys) ---
-        KeyCode::Up => fi.pitch_delta += 1.0,
-        KeyCode::Down => fi.pitch_delta -= 1.0,
-        KeyCode::Left => fi.yaw_delta -= 1.0,
-        KeyCode::Right => fi.yaw_delta += 1.0,
+    #[test]
+    fn apply_key_shift_w_marks_run() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        apply_key(&mut st, press(KeyCode::Char('w'), KeyModifiers::SHIFT), t0);
+        assert!(st.shift_held);
+    }
 
-        // --- Modes ---
-        KeyCode::F(1) => fi.toggle_fps_off = true,
+    #[test]
+    fn apply_key_uppercase_w_also_marks_run() {
+        // Some terminals deliver 'W' as Char('W') with no SHIFT bit.
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        apply_key(&mut st, press(KeyCode::Char('W'), KeyModifiers::NONE), t0);
+        assert!(st.is_held(KeyCode::Char('w'), t0));
+        assert!(st.shift_held);
+    }
 
-        // --- Quit ---
-        KeyCode::Esc => fi.quit = true,
-        KeyCode::Char('q') | KeyCode::Char('Q') => fi.quit = true,
+    #[test]
+    fn apply_key_f1_returns_toggle() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::F(1), KeyModifiers::NONE), t0);
+        assert_eq!(action, Some(InputAction::ToggleFpsOff));
+    }
 
-        _ => {}
+    #[test]
+    fn apply_key_esc_returns_quit() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::Esc, KeyModifiers::NONE), t0);
+        assert_eq!(action, Some(InputAction::Quit));
+    }
+
+    #[test]
+    fn apply_key_q_returns_quit() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::Char('q'), KeyModifiers::NONE), t0);
+        assert_eq!(action, Some(InputAction::Quit));
+    }
+
+    #[test]
+    fn apply_key_space_returns_jump() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::Char(' '), KeyModifiers::NONE), t0);
+        assert_eq!(action, Some(InputAction::Jump));
+    }
+
+    #[test]
+    fn apply_key_unmapped_does_nothing() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        let action = apply_key(&mut st, press(KeyCode::Char('z'), KeyModifiers::NONE), t0);
+        assert!(action.is_none());
+        assert!(st.key_last_seen.is_empty());
+    }
+
+    #[test]
+    fn release_drops_key_from_held_table() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        apply_key(&mut st, press(KeyCode::Char('w'), KeyModifiers::NONE), t0);
+        assert!(st.is_held(KeyCode::Char('w'), t0));
+        apply_key(&mut st, release(KeyCode::Char('w')), t0);
+        assert!(!st.is_held(KeyCode::Char('w'), t0));
+    }
+
+    #[test]
+    fn held_expires_after_timeout() {
+        let mut st = InputState::new();
+        let t0 = Instant::now();
+        apply_key(&mut st, press(KeyCode::Char('w'), KeyModifiers::NONE), t0);
+        let later = t0 + KEY_HOLD_TIMEOUT + Duration::from_millis(1);
+        assert!(!st.is_held(KeyCode::Char('w'), later));
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,128 @@
+//! Input loop: crossterm key events → high-level frame intents.
+//!
+//! crossterm's raw-mode `KeyEvent` stream only delivers `Press` and `Repeat`
+//! kinds on most terminals (there is no `KeyUp`), so continuous-motion
+//! controls are implemented by treating every observed event as
+//! "apply one frame's worth of motion". Holding W produces repeat events
+//! at the terminal's key-repeat rate and the player glides forward; releasing
+//! simply stops the events. This matches how vintage roguelikes handle
+//! hold-to-move and keeps us away from platform-specific raw keyboard APIs.
+//!
+//! Mouse aim is deliberately deferred to #16; arrow keys are the canonical
+//! #18 aim binding.
+
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+
+/// The collected set of actions triggered in one frame poll.
+///
+/// All fields are zero / `false` in the "nothing happened" baseline;
+/// the frame loop adds them into the player's state via
+/// [`crate::physics`]. `forward` / `strafe` are *event counts*: each
+/// `Press` or `Repeat` of the key bumps them by 1, and the caller
+/// multiplies by [`crate::physics::MOVE_SPEED`] × frame_dt so the motion
+/// per second ends up proportional to the terminal's key-repeat rate
+/// (which the user can tune in their OS settings if they want snappier
+/// controls).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FrameInput {
+    /// Net forward intent. W adds +1, S subtracts 1.
+    pub forward: f64,
+    /// Net strafe intent. D adds +1, A subtracts 1.
+    pub strafe: f64,
+    /// Shift held while moving — apply [`crate::physics::RUN_MULTIPLIER`].
+    pub run: bool,
+    /// A jump was requested this frame.
+    pub jump: bool,
+    /// Net yaw delta in "event units" (Left = -1, Right = +1). The caller
+    /// scales by [`crate::physics::AIM_YAW_RATE`] × dt.
+    pub yaw_delta: f64,
+    /// Net pitch delta. Up = +1 (look up), Down = -1.
+    pub pitch_delta: f64,
+    /// F1 was pressed — toggle FPS OFF (handled by the caller).
+    pub toggle_fps_off: bool,
+    /// Esc or q was pressed — request a clean shutdown.
+    pub quit: bool,
+}
+
+/// Drain all currently-pending crossterm events and fold them into a single
+/// [`FrameInput`]. Returns `Ok(FrameInput::default())` if nothing was
+/// pending after `poll_timeout`.
+///
+/// `poll_timeout` is forwarded to [`event::poll`]; pass `Duration::ZERO`
+/// for a non-blocking read (the common case inside a 60 FPS frame loop).
+pub fn poll_frame_input(poll_timeout: Duration) -> anyhow::Result<FrameInput> {
+    let mut fi = FrameInput::default();
+
+    // First poll with the caller's timeout; subsequent polls must be
+    // non-blocking so we don't wait out the full timeout for each event
+    // in a burst (e.g. a held key).
+    let mut first = true;
+    loop {
+        let wait = if first { poll_timeout } else { Duration::ZERO };
+        first = false;
+        if !event::poll(wait)? {
+            break;
+        }
+        match event::read()? {
+            Event::Key(k) => {
+                // Ignore Release events; we only care about Press / Repeat.
+                // (crossterm raw mode emits Press on most terminals and
+                // Press+Repeat on kitty / win32; Release is rare but we're
+                // future-proof against it.)
+                if matches!(k.kind, KeyEventKind::Release) {
+                    continue;
+                }
+                apply_key(&mut fi, k.code, k.modifiers);
+            }
+            // Non-key events are ignored in #18; mouse aim lands in #16.
+            _ => continue,
+        }
+    }
+
+    Ok(fi)
+}
+
+fn apply_key(fi: &mut FrameInput, code: KeyCode, mods: KeyModifiers) {
+    // Track Shift as the "run" modifier any time a motion key fires.
+    let shift = mods.contains(KeyModifiers::SHIFT);
+
+    match code {
+        // --- Movement ---
+        KeyCode::Char('w') | KeyCode::Char('W') => {
+            fi.forward += 1.0;
+            fi.run |= shift;
+        }
+        KeyCode::Char('s') | KeyCode::Char('S') => {
+            fi.forward -= 1.0;
+            fi.run |= shift;
+        }
+        KeyCode::Char('a') | KeyCode::Char('A') => {
+            fi.strafe -= 1.0;
+            fi.run |= shift;
+        }
+        KeyCode::Char('d') | KeyCode::Char('D') => {
+            fi.strafe += 1.0;
+            fi.run |= shift;
+        }
+
+        // --- Jump ---
+        KeyCode::Char(' ') => fi.jump = true,
+
+        // --- Aim (arrow keys) ---
+        KeyCode::Up => fi.pitch_delta += 1.0,
+        KeyCode::Down => fi.pitch_delta -= 1.0,
+        KeyCode::Left => fi.yaw_delta -= 1.0,
+        KeyCode::Right => fi.yaw_delta += 1.0,
+
+        // --- Modes ---
+        KeyCode::F(1) => fi.toggle_fps_off = true,
+
+        // --- Quit ---
+        KeyCode::Esc => fi.quit = true,
+        KeyCode::Char('q') | KeyCode::Char('Q') => fi.quit = true,
+
+        _ => {}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod disc;
 pub mod enemy;
 pub mod hud;
+pub mod input;
 pub mod menu;
 pub mod palette;
 pub mod physics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,5 @@ pub mod menu;
 pub mod palette;
 pub mod player;
 pub mod portal;
+pub mod render;
 pub mod scene;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod enemy;
 pub mod hud;
 pub mod menu;
 pub mod palette;
+pub mod physics;
 pub mod player;
 pub mod portal;
 pub mod render;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,21 @@ const RAY_MAX_DEPTH: f64 = 32.0;
 struct TerminalGuard;
 
 impl TerminalGuard {
+    /// Enter raw mode and then the alternate screen, returning a guard
+    /// that restores both on drop.
+    ///
+    /// Ordering rationale:
+    /// - If [`enable_raw_mode`] fails, `Self` is never constructed, so
+    ///   `Drop` does not run. That is correct: we never transitioned
+    ///   into raw mode and the terminal is still in its original state,
+    ///   so there is nothing to undo.
+    /// - After [`enable_raw_mode`] succeeds we construct `Self` first,
+    ///   *then* call `execute!(EnterAlternateScreen, Hide)`. If those
+    ///   subsequent calls fail, the guard still exists and its `Drop`
+    ///   will run — disabling raw mode (and best-effort restoring the
+    ///   screen / cursor) so the user's shell is not left in raw mode.
     fn new() -> anyhow::Result<Self> {
         enable_raw_mode()?;
-        // Construct `Self` immediately so that if the subsequent `execute!`
-        // fails, `Drop` still runs and disables raw mode. Otherwise a mid-
-        // construction failure would leak raw mode into the user's shell.
         let guard = Self;
         execute!(stdout(), EnterAlternateScreen, Hide)?;
         Ok(guard)
@@ -96,6 +106,13 @@ fn main() -> anyhow::Result<()> {
     let mut input_state = InputState::new();
 
     loop {
+        // FIXME: ターミナルリサイズに未対応 (#13/#16 で対応予定)
+        // Mark the start of this frame up-front so the pacing sleep at
+        // the bottom accounts for the time spent polling input, running
+        // physics, casting rays and writing to stdout — not just the
+        // physics integration window.
+        let frame_start = Instant::now();
+
         // Poll with a 0-duration timeout so the loop runs at the target
         // frame rate instead of stalling on slow keyboard input.
         let input = poll_frame_input(&mut input_state, Duration::ZERO)?;
@@ -171,7 +188,11 @@ fn main() -> anyhow::Result<()> {
         present(&fb)?;
 
         // --- Frame pacing ---
-        let elapsed = last_tick.elapsed();
+        // Measure from `frame_start` so the sleep compensates for the
+        // full frame (input poll + physics + render + present). Using
+        // `last_tick` here instead would underestimate the elapsed time
+        // because it was re-bound right after the input poll.
+        let elapsed = frame_start.elapsed();
         if elapsed < frame_target {
             std::thread::sleep(frame_target - elapsed);
         }
@@ -189,13 +210,27 @@ fn draw_hud(fb: &mut Framebuffer, player: &Player, fps_off: bool) {
     let glyph_w = font.glyph_width() as i32;
 
     let mode = if fps_off { "FPS-OFF" } else { "FPS" };
-    let text = format!(
+    let full = format!(
         "pos=({:.1},{:.1},{:.1}) yaw={:.2} pitch={:.2} vz={:.1} hp={} MODE={}",
         player.x, player.y, player.z, player.yaw, player.pitch, player.vz, player.hp, mode
     );
 
     let fb_h = fb.height() as i32;
     let fb_w = fb.width() as i32;
+
+    // Prefer the verbose form; fall back to a compact single-line read-out
+    // when the framebuffer isn't wide enough to fit it. The short form
+    // drops the vz / mode labels and uses single-letter prefixes.
+    let full_px = 2 + full.chars().count() as i32 * glyph_w;
+    let text = if full_px <= fb_w {
+        full
+    } else {
+        format!(
+            "P{:.1},{:.1} Y{:.2} P{:.0} V{:.0} H{} {}",
+            player.x, player.y, player.yaw, player.pitch, player.vz, player.hp, mode
+        )
+    };
+
     let y = (fb_h - glyph_h - 2).max(0);
 
     for (i, ch) in text.chars().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,41 @@
-//! friendly-filer — FPS skeleton demo frame (Issue #8).
+//! friendly-filer — FPS frame loop (Issue #18).
 //!
-//! Renders a single TRON-styled frame for ~0.8 seconds and exits:
-//! black background, blue floor grid fading toward the horizon, a red
-//! enemy placeholder in the middle, and a small blue label at the bottom.
-//! Real input loop, enemy AI, disc physics and filesystem reads land in
-//! the #9–#18 sub-issues.
+//! Enters an alternate screen, drives a 60 FPS termray raycaster render
+//! loop, and wires crossterm key events through the physics module into
+//! the player pose. Esc / q quit cleanly. Enemy AI, disc physics, sprites
+//! and the real HUD arrive with #9 / #10 / #13; the HUD line at the bottom
+//! of the screen is a minimal debug readout.
 
-use std::io::{Write, stdout};
+use std::io::stdout;
+use std::time::{Duration, Instant};
 
 use crossterm::cursor::{Hide, Show};
 use crossterm::execute;
-use crossterm::style::{
-    Color as CtColor, Print, ResetColor, SetBackgroundColor, SetForegroundColor,
-};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
 };
-use termray::Framebuffer;
 use termray::label::{Font8x8, GlyphRenderer};
+use termray::{Framebuffer, render_floor_ceiling, render_walls};
 
-use friendly_filer::enemy::Enemy;
-use friendly_filer::palette::{BG_BLACK, ENEMY_RED, GEOMETRY_GRAY, GRID_BLUE, UI_BLUE};
+use friendly_filer::input::poll_frame_input;
+use friendly_filer::palette::{BG_BLACK, UI_BLUE};
+use friendly_filer::physics::{
+    AIM_PITCH_RATE, AIM_YAW_RATE, GROUND_Z, MOVE_SPEED, RUN_MULTIPLIER, add_pitch, add_yaw,
+    step_gravity, step_movement, try_jump,
+};
+use friendly_filer::player::Player;
+use friendly_filer::render::{FloorTextureGrid, WallTextureFlat, present};
 use friendly_filer::scene::DirScene;
 
-/// Number of vertical grid lines converging on the vanishing point. Odd, so
-/// that one line sits dead centre. Raising this value packs the near rows
-/// tighter (the fan spreads the same width across more stems).
-const GRID_LINE_COUNT: i32 = 13;
+/// Target frame time in milliseconds. 16 ms ≈ 62.5 FPS — the terminal
+/// half-block renderer isn't pixel-perfect enough for higher rates to
+/// make a visible difference, and staying here keeps CPU usage polite.
+const FRAME_MS: u64 = 16;
+
+/// Maximum raycaster depth in world units. The 8×8 placeholder arena is
+/// bounded by 7.something units so 32 is comfortably beyond the far wall
+/// without wasting DDA steps on empty space.
+const RAY_MAX_DEPTH: f64 = 32.0;
 
 /// RAII guard that enters the alternate screen in raw mode on construction
 /// and restores the terminal on drop. Ensures the terminal is cleaned up
@@ -65,235 +74,134 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // --- Scene + per-frame state ---
     let scene = DirScene::placeholder();
-    let mut fb = Framebuffer::new(fb_w, fb_h);
-    draw_tron_demo(&mut fb, &scene);
+    let mut player = Player::new(scene.player_spawn.0, scene.player_spawn.1, scene.spawn_yaw);
+    player.z = GROUND_Z;
 
+    let mut camera = scene.camera();
+    camera.set_z(GROUND_Z);
+
+    let wall_tx = WallTextureFlat;
+    let floor_tx = FloorTextureGrid;
+
+    let mut fb = Framebuffer::new(fb_w, fb_h);
+    let mut fps_off = false;
+
+    // --- Enter the alternate screen, then run the frame loop ---
     let _guard = TerminalGuard::new()?;
 
-    render_frame(&fb)?;
+    let frame_target = Duration::from_millis(FRAME_MS);
+    let mut last_tick = Instant::now();
 
-    // Fixed display time so the demo frame is visible before exit. Replaced
-    // by the real input loop + frame pacing in the #18 / #13 sub-issues.
-    std::thread::sleep(std::time::Duration::from_millis(800));
+    loop {
+        // Poll with a 0-duration timeout so the loop runs at the target
+        // frame rate instead of stalling on slow keyboard input.
+        let input = poll_frame_input(Duration::ZERO)?;
+        if input.quit {
+            break;
+        }
+        if input.toggle_fps_off {
+            fps_off = !fps_off;
+        }
+
+        // --- dt ---
+        let now = Instant::now();
+        let dt = now.duration_since(last_tick).as_secs_f64().min(0.1);
+        last_tick = now;
+
+        // --- Motion ---
+        // Each event is one frame's worth; scale by MOVE_SPEED × dt so the
+        // speed stays consistent if the terminal changes key-repeat rate.
+        let speed = if input.run {
+            MOVE_SPEED * RUN_MULTIPLIER
+        } else {
+            MOVE_SPEED
+        };
+        step_movement(
+            &mut player,
+            input.forward * speed,
+            input.strafe * speed,
+            dt,
+            scene.map(),
+        );
+
+        // --- Jump + gravity ---
+        if input.jump {
+            try_jump(&mut player);
+        }
+        step_gravity(&mut player, dt);
+
+        // --- Aim ---
+        if input.yaw_delta != 0.0 {
+            add_yaw(&mut player, input.yaw_delta * AIM_YAW_RATE * dt);
+        }
+        if input.pitch_delta != 0.0 {
+            add_pitch(&mut player, input.pitch_delta * AIM_PITCH_RATE * dt);
+        }
+
+        // --- Sync camera from player pose ---
+        camera.set_pose(player.x, player.y, player.yaw);
+        camera.set_z(player.z);
+        camera.set_pitch(player.pitch);
+
+        // --- Render ---
+        fb.clear(BG_BLACK);
+        let rays = camera.cast_all_rays(scene.map(), fb.width(), RAY_MAX_DEPTH);
+        render_floor_ceiling(
+            &mut fb,
+            &rays,
+            &floor_tx,
+            scene.heights(),
+            &camera,
+            RAY_MAX_DEPTH,
+        );
+        render_walls(
+            &mut fb,
+            &rays,
+            &wall_tx,
+            scene.heights(),
+            &camera,
+            RAY_MAX_DEPTH,
+        );
+
+        draw_hud(&mut fb, &player, fps_off);
+
+        present(&fb)?;
+
+        // --- Frame pacing ---
+        let elapsed = last_tick.elapsed();
+        if elapsed < frame_target {
+            std::thread::sleep(frame_target - elapsed);
+        }
+    }
 
     Ok(())
 }
 
-/// Paint the TRON skeleton frame directly into the framebuffer. Order:
-/// clear → floor grid → horizon bar → enemy placeholder → HUD banner.
-fn draw_tron_demo(fb: &mut Framebuffer, scene: &DirScene) {
-    fb.clear(BG_BLACK);
-
-    let w = fb.width();
-    let h = fb.height();
-    if w == 0 || h == 0 {
-        return;
-    }
-
-    // Horizon sits slightly above centre — leaves more floor area for the
-    // grid, mimicking the termray camera tilt we'll adopt in #18.
-    let horizon = h / 2;
-
-    // ---------- Floor grid ----------
-    //
-    // A fake-perspective grid: lines spaced ~8 px on the near rows, spacing
-    // contracting toward the horizon. Cheap stand-in for real ray-floor
-    // intersection, which termray gives us in #3 / #9.
-    draw_floor_grid(fb, horizon);
-
-    // ---------- Horizon strip ----------
-    //
-    // A single bright blue line delineating ground from void.
-    for x in 0..w {
-        fb.set_pixel(x, horizon, GRID_BLUE);
-    }
-
-    // ---------- Enemy placeholder ----------
-    //
-    // Centred red rectangle driven by the first enemy in `scene`. Real
-    // per-enemy projection arrives with #9; here we just consume the
-    // scene's demo `Enemy` to prove the `DirScene → renderer` wire works.
-    if let Some(enemy) = scene.enemies.first() {
-        draw_enemy_placeholder(fb, horizon, enemy);
-    }
-
-    // ---------- HUD banner ----------
-    //
-    // Keep the version in sync with `Cargo.toml` by reading it from cargo at
-    // build time; `-dev` tracks the pre-release state of the #8 branch.
-    let banner = concat!(
-        "FRIENDLY-FILER v",
-        env!("CARGO_PKG_VERSION"),
-        "-dev - TRON MODE - #8"
-    );
-    draw_banner(fb, banner);
-}
-
-/// Thin blue horizontal lines at receding vertical spacing above the near
-/// edge, plus thin blue verticals converging toward the screen centre. Gives
-/// the visual impression of an infinite floor plane without requiring the
-/// real raycaster.
-fn draw_floor_grid(fb: &mut Framebuffer, horizon: usize) {
-    let w = fb.width();
-    let h = fb.height();
-    if horizon + 1 >= h {
-        return;
-    }
-
-    let floor_depth = h - horizon - 1;
-
-    // Horizontal grid lines: start at the near edge with a 2-pixel stride
-    // and widen it toward the horizon for perspective-like compression.
-    // Collect the rows first so the loop is a plain iterator instead of a
-    // manual underflow-guarded `while`.
-    let horizontal_rows = {
-        let mut rows = Vec::new();
-        let mut stride = 2usize;
-        let mut y = h - 1;
-        loop {
-            rows.push(y);
-            let next_y = match y.checked_sub(stride) {
-                Some(v) if v > horizon => v,
-                _ => break,
-            };
-            y = next_y;
-            stride = stride.saturating_add(1).min(floor_depth.max(1));
-        }
-        rows
-    };
-    for y in horizontal_rows {
-        for x in 0..w {
-            fb.set_pixel(x, y, GRID_BLUE);
-        }
-    }
-
-    // Vertical grid lines converge on a vanishing point at (cx, horizon).
-    // Sampling each floor row and projecting x positions outward produces
-    // the classic TRON perspective fan.
-    let cx = w as f64 / 2.0;
-    let half = GRID_LINE_COUNT / 2;
-    for y_row in (horizon + 1)..h {
-        let d = (y_row - horizon) as f64; // distance below horizon, in pixels
-        // Scale of the near plane relative to depth.
-        let spread = d / (floor_depth.max(1) as f64) * (w as f64 / 1.4);
-        for i in -half..=half {
-            let offset = i as f64 * spread / half as f64;
-            let x = cx + offset;
-            if x >= 0.0 && (x as usize) < w {
-                fb.set_pixel(x as usize, y_row, GRID_BLUE);
-            }
-        }
-    }
-}
-
-/// Red rectangle standing on the floor, roughly where the first hostile
-/// wireframe will be rendered by the real enemy pass. Filled in
-/// [`GEOMETRY_GRAY`] with an [`ENEMY_RED`] outline so the silhouette reads
-/// against the blue grid.
-///
-/// The `enemy` argument drives the screen-space placement via a trivial
-/// perspective-stand-in: `enemy.x` shifts the box horizontally around the
-/// screen centre, and `enemy.y` (forward distance in scene units) pushes it
-/// deeper into the floor. Real termray sprite projection arrives in #9.
-fn draw_enemy_placeholder(fb: &mut Framebuffer, horizon: usize, enemy: &Enemy) {
-    let w = fb.width();
-    let h = fb.height();
-
-    // Size the box as a fraction of screen dims so it scales with the
-    // terminal. Minimum dimensions keep it visible on 80×24.
-    let box_w = (w / 10).max(6);
-    let box_h = (h / 5).max(8);
-
-    // Project scene -> screen with a deliberately simple model: the
-    // vanishing point sits at (w/2, horizon); increasing `enemy.y` moves the
-    // base toward the horizon (smaller floor depth used), and `enemy.x`
-    // offsets horizontally scaled by that same depth. Good enough to
-    // demonstrate that `DirScene` data reaches the renderer.
-    let floor_depth = (h - horizon).max(1) as f64;
-    let depth_t = (enemy.y / 8.0).clamp(0.0, 0.95);
-    let base_offset = (floor_depth * (1.0 - depth_t) / 4.0).max(1.0) as usize;
-    let base_y = (horizon + base_offset).min(h.saturating_sub(1));
-    let screen_x_offset = enemy.x * (floor_depth * (1.0 - depth_t) / 16.0);
-    let cx = ((w as f64 / 2.0) + screen_x_offset).clamp(0.0, w as f64) as usize;
-
-    let top_y = base_y.saturating_sub(box_h);
-    let x0 = cx.saturating_sub(box_w / 2);
-    let x1 = (x0 + box_w).min(w);
-
-    // Gray fill.
-    for y in top_y..base_y {
-        for x in x0..x1 {
-            fb.set_pixel(x, y, GEOMETRY_GRAY);
-        }
-    }
-
-    // Red outline (top, bottom, sides). `set_pixel` is bounds-checked
-    // internally, so we don't need to guard `base_y - 1` / `x1 - 1` here.
-    for x in x0..x1 {
-        fb.set_pixel(x, top_y, ENEMY_RED);
-        fb.set_pixel(x, base_y.saturating_sub(1), ENEMY_RED);
-    }
-    for y in top_y..base_y {
-        fb.set_pixel(x0, y, ENEMY_RED);
-        fb.set_pixel(x1.saturating_sub(1), y, ENEMY_RED);
-    }
-}
-
-/// Draw a short ASCII banner near the bottom of the framebuffer, using
-/// termray's built-in 8×8 font. The text is clipped automatically by
-/// [`Font8x8::draw_glyph`], which skips out-of-range characters.
-fn draw_banner(fb: &mut Framebuffer, text: &str) {
+/// Tiny debug HUD shown at the bottom-left of the frame. Full HUD with HP
+/// bars, minimap and mode ornaments lands with Issue #13; for now we just
+/// need to see that movement / jumps / aim are affecting state.
+fn draw_hud(fb: &mut Framebuffer, player: &Player, fps_off: bool) {
     let font = Font8x8;
-    let glyph_w = font.glyph_width() as i32;
     let glyph_h = font.glyph_height() as i32;
+    let glyph_w = font.glyph_width() as i32;
 
-    let total_w = glyph_w * text.len() as i32;
-    let fb_w = fb.width() as i32;
+    let mode = if fps_off { "FPS-OFF" } else { "FPS" };
+    let text = format!(
+        "pos=({:.1},{:.1},{:.1}) yaw={:.2} pitch={:.2} vz={:.1} hp={} MODE={}",
+        player.x, player.y, player.z, player.yaw, player.pitch, player.vz, player.hp, mode
+    );
+
     let fb_h = fb.height() as i32;
-
-    // Centre horizontally, sit 2 glyphs above the bottom.
-    let start_x = ((fb_w - total_w) / 2).max(0);
-    let y = (fb_h - glyph_h * 2).max(0);
+    let fb_w = fb.width() as i32;
+    let y = (fb_h - glyph_h - 2).max(0);
 
     for (i, ch) in text.chars().enumerate() {
-        let x = start_x + i as i32 * glyph_w;
-        if x >= fb_w {
+        let x = 2 + i as i32 * glyph_w;
+        if x + glyph_w > fb_w {
             break;
         }
         font.draw_glyph(fb, x, y, ch, UI_BLUE);
     }
-}
-
-/// Present the framebuffer using half-block characters: one cell = top pixel
-/// (foreground) + bottom pixel (background).
-fn render_frame(fb: &Framebuffer) -> anyhow::Result<()> {
-    let mut out = stdout();
-    let height = fb.height();
-    if height == 0 {
-        return Ok(());
-    }
-    for y in (0..height).step_by(2) {
-        for x in 0..fb.width() {
-            let top = fb.get_pixel(x, y);
-            let bot = fb.get_pixel(x, (y + 1).min(height - 1));
-            execute!(
-                out,
-                SetForegroundColor(CtColor::Rgb {
-                    r: top.r,
-                    g: top.g,
-                    b: top.b
-                }),
-                SetBackgroundColor(CtColor::Rgb {
-                    r: bot.r,
-                    g: bot.g,
-                    b: bot.b
-                }),
-                Print("\u{2580}"),
-            )?;
-        }
-        execute!(out, ResetColor, Print("\r\n"))?;
-    }
-    out.flush()?;
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use crossterm::terminal::{
 use termray::label::{Font8x8, GlyphRenderer};
 use termray::{Framebuffer, render_floor_ceiling, render_walls};
 
-use friendly_filer::input::poll_frame_input;
+use friendly_filer::input::{InputState, poll_frame_input};
 use friendly_filer::palette::{BG_BLACK, UI_BLUE};
 use friendly_filer::physics::{
     AIM_PITCH_RATE, AIM_YAW_RATE, GROUND_Z, MOVE_SPEED, RUN_MULTIPLIER, add_pitch, add_yaw,
@@ -93,11 +93,12 @@ fn main() -> anyhow::Result<()> {
 
     let frame_target = Duration::from_millis(FRAME_MS);
     let mut last_tick = Instant::now();
+    let mut input_state = InputState::new();
 
     loop {
         // Poll with a 0-duration timeout so the loop runs at the target
         // frame rate instead of stalling on slow keyboard input.
-        let input = poll_frame_input(Duration::ZERO)?;
+        let input = poll_frame_input(&mut input_state, Duration::ZERO)?;
         if input.quit {
             break;
         }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,0 +1,311 @@
+//! Player physics: movement + gravity + jump + camera aim.
+//!
+//! Pure functions operating on [`crate::player::Player`] state. No rendering,
+//! no input: the frame loop reads the current input vector, calls
+//! [`step_movement`] / [`step_gravity`] / [`try_jump`] / [`add_yaw`] /
+//! [`add_pitch`], and pushes the resulting pose into the termray camera.
+//!
+//! Every tunable is a module-level `pub const`. Config-file overrides land
+//! with Issue #17; until then tweaking a constant here is the intended
+//! workflow.
+
+use std::f64::consts::{FRAC_PI_2, TAU};
+
+use termray::TileMap;
+
+use crate::player::Player;
+
+/// Baseline walking speed, in world units per second. Combined with
+/// [`RUN_MULTIPLIER`] when the player holds Shift.
+pub const MOVE_SPEED: f64 = 3.0;
+
+/// Multiplier applied to [`MOVE_SPEED`] while the run modifier (Shift) is
+/// held. Tuned so sprinting feels distinct from walking but does not skip
+/// past collision checks in a single frame at 60 FPS (3.0 × 1.8 / 60 ≈
+/// 0.09 units / frame, much less than [`PLAYER_RADIUS`]).
+pub const RUN_MULTIPLIER: f64 = 1.8;
+
+/// Initial upward velocity applied when the player triggers a jump, in
+/// world units per second. Combined with [`GRAVITY`] this yields a peak
+/// height of `JUMP_INITIAL_VZ² / (2·GRAVITY)` ≈ 0.84 units — enough to
+/// clear a low portal step (see #11) without leaving the room's 1-unit
+/// ceiling.
+pub const JUMP_INITIAL_VZ: f64 = 4.5;
+
+/// Downward gravitational acceleration, world units / second². Larger
+/// value = snappier, arcade-ier jumps. The current tuning gives a total
+/// airtime of `2·JUMP_INITIAL_VZ / GRAVITY` ≈ 0.75 s.
+pub const GRAVITY: f64 = 12.0;
+
+/// Eye height when standing on the floor. Matches
+/// [`termray::Camera::new`]'s default `z = 0.5`, so the camera sits in
+/// the vertical middle of a 1-unit-tall cell.
+pub const GROUND_Z: f64 = 0.5;
+
+/// Yaw rotation speed from the arrow keys, radians / second. Roughly
+/// equivalent to one full 360° turn per 3 seconds when the key is held.
+pub const AIM_YAW_RATE: f64 = 2.0;
+
+/// Pitch rotation speed from the arrow keys, radians / second.
+pub const AIM_PITCH_RATE: f64 = 1.5;
+
+/// Upper bound (in radians) on `|pitch|`. termray's pitch uses a
+/// `tan(pitch)` horizon shift which diverges at ±π/2; a 0.05-rad margin
+/// keeps the math well-conditioned without visibly clipping extreme looks.
+pub const PITCH_MAX: f64 = FRAC_PI_2 - 0.05;
+
+/// Collision radius used by [`step_movement`]. The player is modelled as
+/// a circle of this radius on the floor plane; movement is rejected if
+/// the circle would overlap a solid cell. 0.25 leaves a visible gap
+/// between the camera and the walls without feeling spongy.
+pub const PLAYER_RADIUS: f64 = 0.25;
+
+/// Advance the player's horizontal position along the camera's facing
+/// direction using an axis-aligned Doom-style slide.
+///
+/// - `forward` is the signed scalar along the view direction
+///   (+1 = W, −1 = S, after scaling by [`MOVE_SPEED`] × `dt` × optional
+///   [`RUN_MULTIPLIER`] by the caller).
+/// - `strafe` is the same convention but along the right-hand strafe
+///   direction (+1 = D, −1 = A).
+///
+/// Each axis (x, y) is tested independently: if moving in x alone would
+/// collide with a wall (as decided by [`TileMap::is_solid`] considering
+/// [`PLAYER_RADIUS`]), the x component is dropped but y may still
+/// succeed — giving the classic "slide along the wall" feel without
+/// requiring a full circle / rectangle sweep.
+pub fn step_movement(player: &mut Player, forward: f64, strafe: f64, dt: f64, map: &dyn TileMap) {
+    let (sin, cos) = player.yaw.sin_cos();
+    // forward: (cos, sin), right: (-sin, cos). Same convention as
+    // termray::Camera::{forward, right}.
+    let dx = (cos * forward + -sin * strafe) * dt;
+    let dy = (sin * forward + cos * strafe) * dt;
+
+    if !blocked_at(map, player.x + dx, player.y) {
+        player.x += dx;
+    }
+    if !blocked_at(map, player.x, player.y + dy) {
+        player.y += dy;
+    }
+}
+
+/// Test whether a circle of [`PLAYER_RADIUS`] centred at `(x, y)` would
+/// overlap any solid tile in `map`. Samples the four cardinal edges of
+/// the bounding box; that's enough for axis-aligned grid walls and
+/// avoids the cost of a full per-corner sweep.
+fn blocked_at(map: &dyn TileMap, x: f64, y: f64) -> bool {
+    let r = PLAYER_RADIUS;
+    for (tx, ty) in [
+        (x - r, y),
+        (x + r, y),
+        (x, y - r),
+        (x, y + r),
+        // Diagonal corners as well, so the player can't squeeze through
+        // a 45° gap between two walls.
+        (x - r, y - r),
+        (x + r, y - r),
+        (x - r, y + r),
+        (x + r, y + r),
+    ] {
+        let cx = tx.floor() as i32;
+        let cy = ty.floor() as i32;
+        if map.is_solid(cx, cy) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Integrate gravity over `dt`, clamping the player onto the floor at
+/// [`GROUND_Z`]. Leaves `player.z` unchanged when the player is grounded
+/// and not moving vertically.
+pub fn step_gravity(player: &mut Player, dt: f64) {
+    if player.z <= GROUND_Z && player.vz == 0.0 {
+        // Already at rest on the floor. Skip the integration so
+        // floating-point drift doesn't lift the player off the ground.
+        return;
+    }
+    player.vz -= GRAVITY * dt;
+    player.z += player.vz * dt;
+    if player.z <= GROUND_Z {
+        player.z = GROUND_Z;
+        player.vz = 0.0;
+    }
+}
+
+/// Apply a jump impulse if the player is standing on the floor. Returns
+/// `true` if a jump was actually issued (so the HUD / sfx can react), or
+/// `false` if the request was ignored (already airborne).
+pub fn try_jump(player: &mut Player) -> bool {
+    if player.z == GROUND_Z && player.vz == 0.0 {
+        player.vz = JUMP_INITIAL_VZ;
+        true
+    } else {
+        false
+    }
+}
+
+/// Add `delta` radians to the player's yaw, wrapping into `[0, 2π)`.
+/// Using the full positive range matches
+/// [`termray::math::normalize_angle`]'s convention.
+pub fn add_yaw(player: &mut Player, delta: f64) {
+    player.yaw = (player.yaw + delta).rem_euclid(TAU);
+}
+
+/// Add `delta` radians to the player's pitch, clamping to
+/// `±`[`PITCH_MAX`] so the `tan(pitch)` horizon shift never diverges.
+pub fn add_pitch(player: &mut Player, delta: f64) {
+    player.pitch = (player.pitch + delta).clamp(-PITCH_MAX, PITCH_MAX);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fully-walkable placeholder map: 4×4 with every cell [`TILE_EMPTY`].
+    struct OpenMap;
+    impl TileMap for OpenMap {
+        fn width(&self) -> usize {
+            4
+        }
+        fn height(&self) -> usize {
+            4
+        }
+        fn get(&self, _x: i32, _y: i32) -> Option<termray::TileType> {
+            Some(termray::TILE_EMPTY)
+        }
+        fn is_solid(&self, _x: i32, _y: i32) -> bool {
+            false
+        }
+    }
+
+    /// Grid with a single solid pillar at `(2, 2)`.
+    struct PillarMap;
+    impl TileMap for PillarMap {
+        fn width(&self) -> usize {
+            4
+        }
+        fn height(&self) -> usize {
+            4
+        }
+        fn get(&self, x: i32, y: i32) -> Option<termray::TileType> {
+            if (x, y) == (2, 2) {
+                Some(termray::TILE_WALL)
+            } else {
+                Some(termray::TILE_EMPTY)
+            }
+        }
+        fn is_solid(&self, x: i32, y: i32) -> bool {
+            (x, y) == (2, 2)
+        }
+    }
+
+    fn spawn() -> Player {
+        let mut p = Player::new(1.5, 1.5, 0.0);
+        p.z = GROUND_Z;
+        p
+    }
+
+    #[test]
+    fn step_movement_advances_on_open_map() {
+        let mut p = spawn();
+        step_movement(&mut p, 1.0, 0.0, 0.1, &OpenMap);
+        // forward = +x at yaw 0; so x should have grown, y unchanged.
+        assert!(p.x > 1.5);
+        assert!((p.y - 1.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn step_movement_blocked_by_wall_leaves_x_unchanged() {
+        // Stand just west of the pillar at (2, 2) and try to walk into it.
+        let mut p = Player::new(1.8, 2.5, 0.0);
+        p.z = GROUND_Z;
+        let before = (p.x, p.y);
+        step_movement(&mut p, 5.0, 0.0, 0.1, &PillarMap);
+        // Pushing straight east into the solid cell at (2,2) must not
+        // move us into it. The axis-aligned slide rejects the x step
+        // and the player stays at the starting x.
+        assert!((p.x - before.0).abs() < 1e-12);
+        // y was untouched since we didn't supply a strafe.
+        assert!((p.y - before.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn step_movement_slides_along_wall_when_blocked_on_one_axis() {
+        // Stand west of the pillar at (2, 2). Push north-east: x is blocked,
+        // y should still move (slide north).
+        let mut p = Player::new(1.8, 2.5, 0.0);
+        p.z = GROUND_Z;
+        // yaw = 0 -> forward is +x. strafe = -1 at yaw 0 means -right = +y
+        // reversed... simpler: set yaw so forward = +y (north). Push forward
+        // + strafe where strafe enters the pillar on x, but forward slides y.
+        p.yaw = std::f64::consts::FRAC_PI_2; // forward = +y
+        let y0 = p.y;
+        step_movement(&mut p, 1.0, 1.0, 0.1, &PillarMap);
+        // y must have moved (forward), x may be blocked by the pillar.
+        assert!(
+            p.y > y0,
+            "expected y to slide forward past the pillar, got {}",
+            p.y
+        );
+    }
+
+    #[test]
+    fn gravity_pulls_z_down_when_airborne() {
+        let mut p = spawn();
+        p.vz = 1.0; // mid-jump, rising
+        let z0 = p.z;
+        step_gravity(&mut p, 0.1);
+        // After 0.1 s the velocity has dropped by 1.2 to -0.2 and z has
+        // risen slightly — but a full second later it must be strictly
+        // below the start.
+        step_gravity(&mut p, 1.0);
+        assert!(
+            p.z <= z0 + 1e-9,
+            "expected z fallen back to ground, got {}",
+            p.z
+        );
+    }
+
+    #[test]
+    fn gravity_clamps_to_ground_and_zeroes_vz() {
+        let mut p = spawn();
+        p.z = GROUND_Z + 0.01;
+        p.vz = -10.0;
+        step_gravity(&mut p, 0.1);
+        assert!((p.z - GROUND_Z).abs() < 1e-12);
+        assert_eq!(p.vz, 0.0);
+    }
+
+    #[test]
+    fn try_jump_only_when_grounded() {
+        let mut p = spawn();
+        assert!(try_jump(&mut p));
+        assert_eq!(p.vz, JUMP_INITIAL_VZ);
+        // Second call while airborne must refuse.
+        assert!(!try_jump(&mut p));
+        // Simulate landing.
+        p.z = GROUND_Z;
+        p.vz = 0.0;
+        assert!(try_jump(&mut p));
+    }
+
+    #[test]
+    fn add_pitch_clamps_at_limit() {
+        let mut p = spawn();
+        add_pitch(&mut p, 100.0);
+        assert!((p.pitch - PITCH_MAX).abs() < 1e-12);
+        add_pitch(&mut p, -100.0);
+        assert!((p.pitch + PITCH_MAX).abs() < 1e-12);
+    }
+
+    #[test]
+    fn add_yaw_wraps_into_zero_tau() {
+        let mut p = spawn();
+        add_yaw(&mut p, TAU + 0.25);
+        assert!(p.yaw >= 0.0 && p.yaw < TAU);
+        assert!((p.yaw - 0.25).abs() < 1e-9);
+        add_yaw(&mut p, -1.0);
+        assert!(p.yaw >= 0.0 && p.yaw < TAU);
+    }
+}

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -75,17 +75,52 @@ pub const PLAYER_RADIUS: f64 = 0.25;
 /// succeed — giving the classic "slide along the wall" feel without
 /// requiring a full circle / rectangle sweep.
 pub fn step_movement(player: &mut Player, forward: f64, strafe: f64, dt: f64, map: &dyn TileMap) {
+    // Defensive: non-positive dt (clock skew, paused frame) must never
+    // advance state. Without this guard a negative dt would actually move
+    // the player *backwards* along the intent vector.
+    if dt <= 0.0 {
+        return;
+    }
+
     let (sin, cos) = player.yaw.sin_cos();
     // forward: (cos, sin), right: (-sin, cos). Same convention as
     // termray::Camera::{forward, right}.
-    let dx = (cos * forward + -sin * strafe) * dt;
+    let dx = (cos * forward - sin * strafe) * dt;
     let dy = (sin * forward + cos * strafe) * dt;
 
-    if !blocked_at(map, player.x + dx, player.y) {
-        player.x += dx;
+    let start_x = player.x;
+    let start_y = player.y;
+
+    // Axis-aligned slide: try x alone, then y alone from the post-x
+    // position. Either or both may be rejected — the surviving axis
+    // still counts as motion.
+    if !blocked_at(map, start_x + dx, start_y) {
+        player.x = start_x + dx;
     }
-    if !blocked_at(map, player.x, player.y + dy) {
-        player.y += dy;
+    if !blocked_at(map, player.x, start_y + dy) {
+        player.y = start_y + dy;
+    }
+
+    // Inside-corner rescue: the per-axis checks above each look at a
+    // bounding box plus four diagonal corners, but the combined
+    // `(new_x, new_y)` position can still end up inside a solid tile if
+    // the axes are committed in sequence (the x move opens a slot the
+    // subsequent y move then overlaps). Re-check the final pose and
+    // unwind the second-committed axis (y) first, then x, preferring
+    // "slide on one axis" over "stop entirely" when possible.
+    if blocked_at(map, player.x, player.y) {
+        // Undo y, keep x. If that is still blocked, undo x instead and
+        // keep the original y-only attempt.
+        player.y = start_y;
+        if blocked_at(map, player.x, player.y) {
+            player.x = start_x;
+            // Try the y-only attempt from the fresh start.
+            if !blocked_at(map, start_x, start_y + dy) {
+                player.y = start_y + dy;
+            }
+            // If that is still blocked we've simply stopped — both axes
+            // lose and the player remains at the original position.
+        }
     }
 }
 
@@ -123,13 +158,18 @@ pub fn step_gravity(player: &mut Player, dt: f64) {
     if player.z <= GROUND_Z && player.vz == 0.0 {
         // Already at rest on the floor. Skip the integration so
         // floating-point drift doesn't lift the player off the ground.
+        player.on_ground = true;
         return;
     }
+    // Any non-zero vz means the player has left the ground (either from
+    // a jump or from walking off a ledge with negative vz).
+    player.on_ground = false;
     player.vz -= GRAVITY * dt;
     player.z += player.vz * dt;
     if player.z <= GROUND_Z {
         player.z = GROUND_Z;
         player.vz = 0.0;
+        player.on_ground = true;
     }
 }
 
@@ -137,8 +177,9 @@ pub fn step_gravity(player: &mut Player, dt: f64) {
 /// `true` if a jump was actually issued (so the HUD / sfx can react), or
 /// `false` if the request was ignored (already airborne).
 pub fn try_jump(player: &mut Player) -> bool {
-    if player.z == GROUND_Z && player.vz == 0.0 {
+    if player.on_ground {
         player.vz = JUMP_INITIAL_VZ;
+        player.on_ground = false;
         true
     } else {
         false
@@ -250,6 +291,120 @@ mod tests {
         );
     }
 
+    /// Map with an inside-corner: cells `(2, 2)` and `(2, 3)` solid, forming
+    /// an L-shape that the player can try to squeeze into diagonally.
+    struct CornerMap;
+    impl TileMap for CornerMap {
+        fn width(&self) -> usize {
+            5
+        }
+        fn height(&self) -> usize {
+            5
+        }
+        fn get(&self, x: i32, y: i32) -> Option<termray::TileType> {
+            if (x, y) == (2, 2) || (x, y) == (3, 2) {
+                Some(termray::TILE_WALL)
+            } else {
+                Some(termray::TILE_EMPTY)
+            }
+        }
+        fn is_solid(&self, x: i32, y: i32) -> bool {
+            (x, y) == (2, 2) || (x, y) == (3, 2)
+        }
+    }
+
+    /// Map where every surrounding cell is solid — the player is in a
+    /// 1-cell prison and cannot move in any direction.
+    struct CageMap;
+    impl TileMap for CageMap {
+        fn width(&self) -> usize {
+            3
+        }
+        fn height(&self) -> usize {
+            3
+        }
+        fn get(&self, x: i32, y: i32) -> Option<termray::TileType> {
+            if (x, y) == (1, 1) {
+                Some(termray::TILE_EMPTY)
+            } else {
+                Some(termray::TILE_WALL)
+            }
+        }
+        fn is_solid(&self, x: i32, y: i32) -> bool {
+            (x, y) != (1, 1)
+        }
+    }
+
+    #[test]
+    fn step_movement_diagonal_into_inside_corner_does_not_phase_through() {
+        // Stand south-west of the L-corner block (2..=3, 2) and push
+        // north-east at 45°. If the axis-aligned slide committed both
+        // axes blindly the player would end up inside the wall row.
+        // The final-position re-check must unwind far enough to keep
+        // the final pose out of every solid cell.
+        let mut p = Player::new(1.7, 1.7, 0.0);
+        p.z = GROUND_Z;
+        // yaw = π/4 so forward points north-east; strafe 0.
+        p.yaw = std::f64::consts::FRAC_PI_4;
+        step_movement(&mut p, 5.0, 0.0, 0.1, &CornerMap);
+        assert!(
+            !CornerMap.is_solid(p.x.floor() as i32, p.y.floor() as i32),
+            "player ended inside a solid cell at ({}, {})",
+            p.x,
+            p.y
+        );
+        // The bounding box must also not overlap a solid tile on any of
+        // the eight sample points used by `blocked_at`.
+        let r = PLAYER_RADIUS;
+        for (tx, ty) in [
+            (p.x - r, p.y),
+            (p.x + r, p.y),
+            (p.x, p.y - r),
+            (p.x, p.y + r),
+            (p.x - r, p.y - r),
+            (p.x + r, p.y - r),
+            (p.x - r, p.y + r),
+            (p.x + r, p.y + r),
+        ] {
+            assert!(
+                !CornerMap.is_solid(tx.floor() as i32, ty.floor() as i32),
+                "player radius overlaps solid cell via ({}, {})",
+                tx,
+                ty
+            );
+        }
+    }
+
+    #[test]
+    fn step_movement_both_axes_blocked_completely_stops() {
+        let mut p = Player::new(1.5, 1.5, 0.0);
+        p.z = GROUND_Z;
+        // yaw = π/4 so both forward x and forward y would push into a wall.
+        p.yaw = std::f64::consts::FRAC_PI_4;
+        let (x0, y0) = (p.x, p.y);
+        step_movement(&mut p, 5.0, 0.0, 0.1, &CageMap);
+        assert!((p.x - x0).abs() < 1e-12, "x should not have moved");
+        assert!((p.y - y0).abs() < 1e-12, "y should not have moved");
+    }
+
+    #[test]
+    fn step_movement_zero_dt_is_noop() {
+        let mut p = spawn();
+        let (x0, y0) = (p.x, p.y);
+        step_movement(&mut p, 1.0, 1.0, 0.0, &OpenMap);
+        assert!((p.x - x0).abs() < 1e-12);
+        assert!((p.y - y0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn step_movement_negative_dt_does_not_advance() {
+        let mut p = spawn();
+        let (x0, y0) = (p.x, p.y);
+        step_movement(&mut p, 1.0, 1.0, -0.1, &OpenMap);
+        assert!((p.x - x0).abs() < 1e-12);
+        assert!((p.y - y0).abs() < 1e-12);
+    }
+
     #[test]
     fn gravity_pulls_z_down_when_airborne() {
         let mut p = spawn();
@@ -282,11 +437,33 @@ mod tests {
         let mut p = spawn();
         assert!(try_jump(&mut p));
         assert_eq!(p.vz, JUMP_INITIAL_VZ);
+        assert!(!p.on_ground);
         // Second call while airborne must refuse.
         assert!(!try_jump(&mut p));
         // Simulate landing.
         p.z = GROUND_Z;
         p.vz = 0.0;
+        p.on_ground = true;
+        assert!(try_jump(&mut p));
+    }
+
+    #[test]
+    fn try_jump_after_jump_returns_false_until_landing() {
+        let mut p = spawn();
+        assert!(try_jump(&mut p));
+        assert!(!p.on_ground);
+        // Several mid-air jump requests must all be refused.
+        for _ in 0..5 {
+            assert!(!try_jump(&mut p));
+        }
+        // Integrate gravity until we land.
+        for _ in 0..200 {
+            step_gravity(&mut p, 0.016);
+            if p.on_ground {
+                break;
+            }
+        }
+        assert!(p.on_ground, "expected player to land after sufficient dt");
         assert!(try_jump(&mut p));
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -24,6 +24,11 @@ pub struct Player {
     pub yaw: f64,
     pub pitch: f64,
     pub vz: f64,
+    /// True while the player is standing on the floor and can initiate a
+    /// jump. Cleared the moment [`crate::physics::try_jump`] fires or the
+    /// player leaves the ground; re-set on landing by
+    /// [`crate::physics::step_gravity`].
+    pub on_ground: bool,
     pub hp: u32,
     pub max_hp: u32,
 }
@@ -38,6 +43,7 @@ impl Player {
             yaw,
             pitch: 0.0,
             vz: 0.0,
+            on_ground: true,
             hp: DEFAULT_MAX_HP,
             max_hp: DEFAULT_MAX_HP,
         }
@@ -64,6 +70,7 @@ mod tests {
         assert_eq!(p.yaw, std::f64::consts::FRAC_PI_2);
         assert_eq!(p.pitch, 0.0);
         assert_eq!(p.vz, 0.0);
+        assert!(p.on_ground);
         assert_eq!(p.hp, DEFAULT_MAX_HP);
         assert_eq!(p.max_hp, DEFAULT_MAX_HP);
         assert!(!p.is_crashed());

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,168 @@
+//! Framebuffer → terminal presentation and the TRON texture adapters.
+//!
+//! This module is the thin shim between termray's generic renderer and
+//! friendly-filer's TRON palette. It owns:
+//!
+//! - [`present`] — writes a [`Framebuffer`] to `stdout` using half-block
+//!   characters (one cell = top + bottom pixel). Extracted out of the
+//!   #8 demo's `main.rs` so both the frame loop and future offline
+//!   renderers can share it.
+//! - [`WallTextureFlat`] — a stub [`WallTexturer`] that paints every wall
+//!   surface with [`palette::GEOMETRY_GRAY`] darkened by distance, outlined
+//!   implicitly by termray's darken-by-distance falloff. Real TRON wall
+//!   treatment (blue edges, per-face shading) lands with #12 / #14.
+//! - [`FloorTextureGrid`] — a two-tone grid [`FloorTexturer`] that alternates
+//!   [`palette::GRID_BLUE`] cell borders against [`palette::BG_BLACK`]
+//!   interiors. Matches the TRON "infinite floor grid" look of the #8
+//!   demo but now driven by real ray-floor intersection.
+
+use std::io::{Write, stdout};
+
+use crossterm::execute;
+use crossterm::style::{
+    Color as CtColor, Print, ResetColor, SetBackgroundColor, SetForegroundColor,
+};
+use termray::{Color, FloorTexturer, Framebuffer, HitSide, TileType, WallTexturer};
+
+use crate::palette::{BG_BLACK, GEOMETRY_GRAY, GRID_BLUE};
+
+/// Width (in world units) of a floor grid line. Cells are 1×1 world units
+/// so any fractional coordinate closer than this to an integer sits inside
+/// a grid line. Tuned so the line is visible at spawn distance without
+/// pixelating into a solid plane near the camera.
+const FLOOR_GRID_LINE_WIDTH: f64 = 0.06;
+
+/// Wall texturer that paints every surface with a single flat gray,
+/// darkened by distance via termray's `brightness` argument. Good enough
+/// for the #18 movement demo; real TRON wall shading (blue rims, per-face
+/// tints) lands with later issues.
+pub struct WallTextureFlat;
+
+impl WallTexturer for WallTextureFlat {
+    fn sample_wall(
+        &self,
+        _tile: TileType,
+        _wall_x: f64,
+        _wall_y: f64,
+        side: HitSide,
+        brightness: f64,
+        _tile_hash: u32,
+    ) -> Color {
+        // Give the two side-classes a slight brightness offset so opposing
+        // walls don't blur into one another when the camera is square-on.
+        // termray's `HitSide::Vertical` = the ray hit a N/S face,
+        // `Horizontal` = E/W face.
+        let side_bias = match side {
+            HitSide::Vertical => 1.0,
+            HitSide::Horizontal => 0.75,
+        };
+        GEOMETRY_GRAY.darken(brightness * side_bias)
+    }
+}
+
+/// Floor / ceiling texturer that draws a blue grid on black. Floor grid
+/// lines sit on integer world-coordinate boundaries; the ceiling is always
+/// background black (for now — the TRON ceiling grid can be enabled later
+/// via config in #17).
+pub struct FloorTextureGrid;
+
+impl FloorTexturer for FloorTextureGrid {
+    fn sample_floor(&self, world_x: f64, world_y: f64, brightness: f64) -> Color {
+        // Distance from the nearest integer in x / y. If either is under
+        // the line-width threshold we're on a grid line.
+        let dx = (world_x - world_x.round()).abs();
+        let dy = (world_y - world_y.round()).abs();
+        if dx < FLOOR_GRID_LINE_WIDTH || dy < FLOOR_GRID_LINE_WIDTH {
+            GRID_BLUE.darken(brightness.clamp(0.0, 1.0))
+        } else {
+            BG_BLACK
+        }
+    }
+
+    fn sample_ceiling(&self, _world_x: f64, _world_y: f64, _brightness: f64) -> Color {
+        BG_BLACK
+    }
+}
+
+/// Write the framebuffer to stdout using the half-block character `▀`:
+/// the top half-pixel becomes the foreground color, the bottom becomes
+/// the background color. Emits `\r\n` between rows so the terminal cursor
+/// resets to column 0 under raw mode (which suppresses the implicit `\r`).
+///
+/// Returns `Ok(())` for a zero-height framebuffer (nothing to present).
+pub fn present(fb: &Framebuffer) -> anyhow::Result<()> {
+    let mut out = stdout();
+    let height = fb.height();
+    if height == 0 {
+        return Ok(());
+    }
+    for y in (0..height).step_by(2) {
+        for x in 0..fb.width() {
+            let top = fb.get_pixel(x, y);
+            let bot = fb.get_pixel(x, (y + 1).min(height - 1));
+            execute!(
+                out,
+                SetForegroundColor(CtColor::Rgb {
+                    r: top.r,
+                    g: top.g,
+                    b: top.b
+                }),
+                SetBackgroundColor(CtColor::Rgb {
+                    r: bot.r,
+                    g: bot.g,
+                    b: bot.b
+                }),
+                Print("\u{2580}"),
+            )?;
+        }
+        execute!(out, ResetColor, Print("\r\n"))?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_grid_returns_blue_on_integer_coord() {
+        let t = FloorTextureGrid;
+        let c = t.sample_floor(2.0, 3.5, 1.0);
+        // On an integer x boundary the sampler must return something
+        // brighter than pure black.
+        assert!(u32::from(c.r) + u32::from(c.g) + u32::from(c.b) > 0);
+    }
+
+    #[test]
+    fn floor_grid_returns_black_interior() {
+        let t = FloorTextureGrid;
+        // Middle of a cell (0.5, 0.5) is far from any integer boundary.
+        let c = t.sample_floor(2.5, 3.5, 1.0);
+        assert_eq!(c.r, BG_BLACK.r);
+        assert_eq!(c.g, BG_BLACK.g);
+        assert_eq!(c.b, BG_BLACK.b);
+    }
+
+    #[test]
+    fn floor_grid_ceiling_is_always_background() {
+        let t = FloorTextureGrid;
+        let c = t.sample_ceiling(2.0, 3.0, 1.0);
+        assert_eq!(c.r, BG_BLACK.r);
+        assert_eq!(c.g, BG_BLACK.g);
+        assert_eq!(c.b, BG_BLACK.b);
+    }
+
+    #[test]
+    fn wall_texture_darkens_with_distance() {
+        let t = WallTextureFlat;
+        let near = t.sample_wall(1, 0.5, 0.5, HitSide::Vertical, 1.0, 0);
+        let far = t.sample_wall(1, 0.5, 0.5, HitSide::Vertical, 0.1, 0);
+        // The near color should be brighter than the far color in at least
+        // one channel.
+        assert!(
+            u32::from(near.r) + u32::from(near.g) + u32::from(near.b)
+                > u32::from(far.r) + u32::from(far.g) + u32::from(far.b)
+        );
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -30,6 +30,12 @@ use crate::palette::{BG_BLACK, GEOMETRY_GRAY, GRID_BLUE};
 /// so any fractional coordinate closer than this to an integer sits inside
 /// a grid line. Tuned so the line is visible at spawn distance without
 /// pixelating into a solid plane near the camera.
+///
+/// Aliasing note: at grazing distances far from the camera the grid lines
+/// shimmer / moiré as adjacent rays alternate between "on-line" and
+/// "off-line" samples. This is **intentional** — the flickering pattern
+/// sells the TRON "infinite digital plane" look. If we ever want a clean
+/// render we'll need supersampling at floor sample time.
 const FLOOR_GRID_LINE_WIDTH: f64 = 0.06;
 
 /// Wall texturer that paints every surface with a single flat gray,

--- a/src/render.rs
+++ b/src/render.rs
@@ -8,11 +8,11 @@
 //!   #8 demo's `main.rs` so both the frame loop and future offline
 //!   renderers can share it.
 //! - [`WallTextureFlat`] — a stub [`WallTexturer`] that paints every wall
-//!   surface with [`palette::GEOMETRY_GRAY`] darkened by distance, outlined
+//!   surface with [`crate::palette::GEOMETRY_GRAY`] darkened by distance, outlined
 //!   implicitly by termray's darken-by-distance falloff. Real TRON wall
 //!   treatment (blue edges, per-face shading) lands with #12 / #14.
 //! - [`FloorTextureGrid`] — a two-tone grid [`FloorTexturer`] that alternates
-//!   [`palette::GRID_BLUE`] cell borders against [`palette::BG_BLACK`]
+//!   [`crate::palette::GRID_BLUE`] cell borders against [`crate::palette::BG_BLACK`]
 //!   interiors. Matches the TRON "infinite floor grid" look of the #8
 //!   demo but now driven by real ray-floor intersection.
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -2,17 +2,41 @@
 //!
 //! Real `read_dir` → [`DirScene`] conversion (LOD, swarm aggregation, portal
 //! seal checks, watch integration) lives in Issue #3 (rebooted under the FPS
-//! layer). This module exists now only to own the struct shape and provide
-//! a placeholder scene so `main.rs` has something to render for the #8
-//! demo frame.
+//! layer). This module currently ships a **placeholder** `DirScene` that
+//! backs the #18 playable demo: a small closed room with a single enemy and
+//! a central monolith, walkable on the termray raycaster.
+
+use termray::{Camera, FlatHeightMap, GridMap, TILE_EMPTY};
 
 use crate::enemy::Enemy;
 use crate::portal::{Monolith, ParentGate, Portal};
 
+/// Edge length (in cells) of the placeholder arena. Small enough that the
+/// full room fits inside a 80×24 terminal's camera frustum at FOV 80°, big
+/// enough that WASD motion is clearly visible.
+const PLACEHOLDER_MAP_SIZE: usize = 8;
+
+/// Default horizontal field of view in radians. 80° feels natural in the
+/// terminal half-block half-resolution; bumping higher amplifies the
+/// fish-eye distortion at the edges.
+const DEFAULT_FOV_RAD: f64 = 80.0 * std::f64::consts::PI / 180.0;
+
 /// The renderable state of a single directory.
-#[derive(Debug, Clone)]
+///
+/// Holds both the simulation-layer data (enemies, portals, monolith) and
+/// the termray-side world geometry (tile map + flat height map) that the
+/// raycaster walks. Real `read_dir`-driven construction lands in #3.
 pub struct DirScene {
+    /// Tile grid consumed by [`termray::cast_ray`] for wall hits and by
+    /// [`crate::physics::step_movement`] for collision.
+    tile_map: GridMap,
+    /// Per-corner floor / ceiling heights. The placeholder uses a flat
+    /// world (floor=0, ceil=1); #11 will introduce portal steps.
+    height_map: FlatHeightMap,
+    /// Player spawn point in world coordinates (cell-center offsets).
     pub player_spawn: (f64, f64),
+    /// Yaw the camera faces at spawn, in radians. `0.0` looks +x.
+    pub spawn_yaw: f64,
     pub enemies: Vec<Enemy>,
     pub portals: Vec<Portal>,
     pub monolith: Monolith,
@@ -20,25 +44,67 @@ pub struct DirScene {
 }
 
 impl DirScene {
-    /// A hard-coded demo scene used by the #8 skeleton: the player spawns at
-    /// the origin, one enemy stands in front of them, there are no portals,
-    /// and the monolith sits behind the player. Swap this out for real
-    /// `read_dir` work in Issue #3.
+    /// An 8×8 closed room used by the #18 playable demo. The outer ring is
+    /// [`termray::TILE_WALL`], the 6×6 interior is [`TILE_EMPTY`] and the
+    /// player spawns one cell in from the NW corner looking east. A single
+    /// demo enemy stands near the far wall; the monolith sits in the middle
+    /// of the room. Swap this out for real `read_dir` work in Issue #3.
     pub fn placeholder() -> Self {
-        let enemy = Enemy::from_metadata("demo.rs".to_string(), 2 * 1024, 0.0, 4.0);
+        let size = PLACEHOLDER_MAP_SIZE;
+        let mut tile_map = GridMap::new(size, size);
+        // Carve a 6×6 open interior inside the all-wall default grid.
+        for y in 1..size - 1 {
+            for x in 1..size - 1 {
+                tile_map.set(x, y, TILE_EMPTY);
+            }
+        }
+
+        // One demo enemy near the far (east) wall so it's visible from
+        // spawn without being pressed against the player's face.
+        let enemy = Enemy::from_metadata("placeholder.txt".to_string(), 8 * 1024, 4.0, 6.0);
+
         Self {
-            player_spawn: (0.0, 0.0),
+            tile_map,
+            height_map: FlatHeightMap,
+            player_spawn: (1.5, 1.5),
+            spawn_yaw: 0.0,
             enemies: vec![enemy],
             portals: Vec::new(),
-            monolith: Monolith { x: 0.0, y: -3.0 },
+            monolith: Monolith { x: 4.0, y: 4.0 },
             parent_gate: None,
         }
+    }
+
+    /// The termray tile grid (walls + empty cells). Movement collision and
+    /// wall raycasting both consult this same map so the player and the
+    /// rays agree on what counts as a wall.
+    pub fn map(&self) -> &GridMap {
+        &self.tile_map
+    }
+
+    /// The termray height map. Flat in the placeholder; per-cell steps will
+    /// arrive with portal geometry in #11.
+    pub fn heights(&self) -> &FlatHeightMap {
+        &self.height_map
+    }
+
+    /// A fresh [`Camera`] positioned at the spawn pose with the default FOV.
+    /// The caller owns the camera and updates it from the player's pose each
+    /// frame via [`Camera::set_pose`] / `set_z` / `set_pitch`.
+    pub fn camera(&self) -> Camera {
+        Camera::new(
+            self.player_spawn.0,
+            self.player_spawn.1,
+            self.spawn_yaw,
+            DEFAULT_FOV_RAD,
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use termray::TileMap;
 
     #[test]
     fn placeholder_has_one_enemy_and_no_portals() {
@@ -46,5 +112,27 @@ mod tests {
         assert_eq!(s.enemies.len(), 1);
         assert!(s.portals.is_empty());
         assert!(s.parent_gate.is_none());
+    }
+
+    #[test]
+    fn placeholder_outer_ring_is_solid_interior_is_walkable() {
+        let s = DirScene::placeholder();
+        let m = s.map();
+        // NW corner is wall.
+        assert!(m.is_solid(0, 0));
+        // A middle interior cell is walkable.
+        assert!(!m.is_solid(3, 3));
+        // East outer wall.
+        assert!(m.is_solid(PLACEHOLDER_MAP_SIZE as i32 - 1, 3));
+    }
+
+    #[test]
+    fn camera_is_at_spawn_with_default_fov() {
+        let s = DirScene::placeholder();
+        let cam = s.camera();
+        assert!((cam.x - 1.5).abs() < 1e-12);
+        assert!((cam.y - 1.5).abs() < 1e-12);
+        assert!((cam.angle - 0.0).abs() < 1e-12);
+        assert!((cam.fov - DEFAULT_FOV_RAD).abs() < 1e-12);
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -37,6 +37,12 @@ pub struct DirScene {
     pub player_spawn: (f64, f64),
     /// Yaw the camera faces at spawn, in radians. `0.0` looks +x.
     pub spawn_yaw: f64,
+    // The following fields are populated by `placeholder()` but not yet
+    // consumed by the render / combat path. They are `pub` so the frame
+    // loop can iterate them once the features land:
+    //   - `enemies`  — wired up in #9 (enemy rendering + AI)
+    //   - `portals`  — wired up in #11 (portal geometry + traversal)
+    //   - `monolith` / `parent_gate` — HUD overlays and navigation in #13
     pub enemies: Vec<Enemy>,
     pub portals: Vec<Portal>,
     pub monolith: Monolith,
@@ -130,9 +136,9 @@ mod tests {
     fn camera_is_at_spawn_with_default_fov() {
         let s = DirScene::placeholder();
         let cam = s.camera();
-        assert!((cam.x - 1.5).abs() < 1e-12);
-        assert!((cam.y - 1.5).abs() < 1e-12);
-        assert!((cam.angle - 0.0).abs() < 1e-12);
+        assert!((cam.x - s.player_spawn.0).abs() < 1e-12);
+        assert!((cam.y - s.player_spawn.1).abs() < 1e-12);
+        assert!((cam.angle - s.spawn_yaw).abs() < 1e-12);
         assert!((cam.fov - DEFAULT_FOV_RAD).abs() < 1e-12);
     }
 }


### PR DESCRIPTION
## 関連 Issue

closes #18

## 概要

プレイヤー入力ループ・物理（重力 / ジャンプ / 壁衝突）・照準回転を実装。同時に **termray の本物の raycaster（Camera + render_walls + render_floor_ceiling）に切替**、PR #19 の手書き静止デモを動く 1 人称視点に置き換える。

これで FPS MVP の土台が動き、後続 #9（敵 AI）/ #10（ディスク）/ #3（実 DirScene）が乗せられる状態になる。

## 変更内容

### src/ 新規モジュール
- **input.rs**: crossterm event poll、キーマップ（WASD / Space / 矢印 / Shift / F1 / Esc / q）
- **physics.rs**: 物理定数（MOVE_SPEED 3.0、RUN_MULTIPLIER 1.8、JUMP_INITIAL_VZ 4.5、GRAVITY 12.0、PITCH_MAX π/2-0.05、PLAYER_RADIUS 0.25）と step_movement / step_gravity / try_jump / add_yaw / add_pitch + ユニットテスト 8 件
- **render.rs**: present ヘルパ + WallTextureFlat + FloorTextureGrid（TRON look 重視で整数境界グリッド）

### src/ 拡張
- **scene.rs**: GridMap / FlatHeightMap を DirScene に追加、placeholder() を 8×8 部屋に拡張、camera() / map() / heights() アクセサ
- **main.rs**: 全面書き換え。Instant ベースの dt 計算、入力 → 物理 → カメラ更新 → cast_all_rays → render_walls → render_floor_ceiling → HUD 行 → present のフレームループ
- **lib.rs**: input / physics / render を pub mod 追加

### docs/
- **architecture.md**: モジュール一覧に input / physics / render を追加、物理定数表、Phase 0 静止デモから動く入力ループへの移行を明記
- **CLAUDE.md**: Architecture / Roadmap 更新、#18 完了マーク
- **CHANGELOG.md**: Unreleased に #18 完了を追記

## 操作（macOS Terminal 想定）

| キー | 動作 |
|---|---|
| W/S | 前後移動 |
| A/D | 左右ストレイフ |
| Shift | 走り（×1.8） |
| Space | ジャンプ（接地時のみ、放物線、~0.75s 滞空） |
| Up/Down | pitch 回転（±π/2-0.05 でクランプ） |
| Left/Right | yaw 回転 |
| F1 | FPS OFF トグル（HUD 表示のみ、AI 停止は #16） |
| Esc / q | 終了 |

壁は axis-aligned スライドで衝突（Doom 風）。HUD は画面下部 Font8x8 で `pos / yaw / pitch / vz / hp / MODE` を UI_BLUE 表示。

## 品質ゲート

- \`cargo fmt --all\` ✅
- \`cargo clippy --all-targets -- -D warnings\` ✅ (warnings 0)
- \`cargo test\` ✅ (24 passed, 0 failed; physics 8 / render 4 / scene 3 新規)
- \`cargo build --release\` ✅ (3.13s)

## スコープ外（後続）

- マウス照準: #16
- FPS OFF の描画切替（敵 AI 停止）: #16
- 敵 AI（ジャンプ・ランジ・赤ディスク）: #9
- ディスク射撃: #10
- ポータル / 石碑 / 親ゲート: #11
- 実 DirScene（FS → シーン）: #3